### PR TITLE
Add a byte array constructor

### DIFF
--- a/src/test/scala/com/github/kolotaev/ride/IdSpec.scala
+++ b/src/test/scala/com/github/kolotaev/ride/IdSpec.scala
@@ -85,6 +85,24 @@ class IdSpec extends FlatSpec with Matchers {
     diff should equal (1)
   }
 
+  "IDs" should "be constructed correctly value when constructed using a bytes-array representation" in {
+    val bytes = Array[Byte](90, 61, 13, 107, 88, -105, 98, 106, -53, -1, -1, -3)
+    val strId = "b8ugqqqoith6livvvvug"
+    val a = Id(bytes)
+    a.getBytes should be (bytes)
+    a.toString should be (strId)
+    a should be (Id(strId))
+  }
+
+  "IDs" should "not increment counter when constructed with byte array" in {
+    val a = Id()
+    Id(a.getBytes)
+    Id(a.getBytes)
+    val c = Id()
+    val diff = c.counter - a.counter
+    diff should equal (1)
+  }
+
   "ID" should "throw IllegalArgumentException if wrong base32 string is passed to constructor" in {
     val data = List(
       "",


### PR DESCRIPTION
Sorry for creating a PR without opening an issue. I needed to get something done over the weekend and I had already made this changes in my local branch.

Adds a new constructor for reconstructing ID instances using a byte array. I needed to do this because I am storing the Ids in the db using ab binary representation, and they needed to be converted back to strings for an API.

Moves out the `decode` method into the companion object so that it can be used during object construction. The `decode` method signature was changed to return a newly constructed byte array instead of working on the instance field. The counter increment no longer happens unless a fresh new XID is being constructed (as opposed to being reconstructed from an existing value).

I have added new tests and all tests are passing.